### PR TITLE
947756: Need to remove the browser scroller for organization and myteam grid module

### DIFF
--- a/src/components/Employees.tsx
+++ b/src/components/Employees.tsx
@@ -127,6 +127,7 @@ const Employees = (props?: { employeeData?: EmployeeDetails; userInfo?: Employee
           pageSettings={{ pageCount: 4, pageSize: 15 }}
           allowExcelExport={true}
           width={'100%'}
+          height={'100%'}
           allowGrouping={true}
           groupSettings={{ enableLazyLoading: true }}
           toolbar={toolbar}

--- a/styles/index.css
+++ b/styles/index.css
@@ -32,7 +32,6 @@
   
   .xyz-management-content {
     position: absolute;
-    height: 650px;
   }
 
   .col-md-10.main-content .row.card-layout {


### PR DESCRIPTION
### Bug description

Need to remove the browser scroller for organization and myteam grid 

### Root cause

To improving the application ui for user friendly.

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

NA.

### Related areas:

NA

### Is it a breaking issue?

No

### Solution description

Fixed the issue by setting the grid parent element as 100vh so that the browser scroller not came.

### Output screenshots

Before

![image](https://github.com/user-attachments/assets/5d05bb5a-224d-41e0-af5c-3bf203915c54)

After

![image](https://github.com/user-attachments/assets/51ac0b38-ef14-4059-9807-a1d52d19ba7f)


### Areas affected and ensured

NA

Ensured the following cases:

- Ensured with all theme and bigger in Grid and pivot.

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - Yes

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? - No